### PR TITLE
fix: use database name provided by user in Query() to get instance

### DIFF
--- a/contracts/database/orm/orm.go
+++ b/contracts/database/orm/orm.go
@@ -8,7 +8,7 @@ import (
 
 type Orm interface {
 	Connection(name string, config *gorm.Config, disableLog bool) Orm
-	Query() DB
+	Query(database ...string) DB
 	Transaction(txFunc func(tx Transaction) error) error
 	WithContext(ctx context.Context) Orm
 }


### PR DESCRIPTION
If user creates a connection and uses it to access Query(), the default instance will be used, unless the user passes in the name of the database, in which case, the instance for that db connection will be used.